### PR TITLE
Rebrand Dowson Farms references to Farm Vista

### DIFF
--- a/access-denied.html
+++ b/access-denied.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Access Not Granted — Dowson Farms</title>
+  <title>Access Not Granted — Farm Vista</title>
 
   <!-- GitHub Pages base -->
-  <base href="/DowsonFarms/">
+  <base href="/FarmVista/">
 
   <!-- theme prepaint -->
   <script>
@@ -40,7 +40,7 @@
 <body>
   <header>
     <img src="assets/icons/icon-192.png" alt="Logo">
-    <div class="title">Dowson Farms</div>
+    <div class="title">Farm Vista</div>
   </header>
 
   <main>

--- a/assets/css/drawer.css
+++ b/assets/css/drawer.css
@@ -1,4 +1,4 @@
-/* Dowson Farms — Drawer (accordion) */
+/* Farm Vista — Drawer (accordion) */
 
 /* Backdrop */
 .drawerBackdrop{

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -1,4 +1,4 @@
-/* Dowson Farms — Global Header (fixed, dark green, white text) */
+/* Farm Vista — Global Header (fixed, dark green, white text) */
 
 html, body { height: 100%; }
 body { padding-top: 64px; }   /* bump to match taller header */

--- a/assets/data/drawer-menus.js
+++ b/assets/data/drawer-menus.js
@@ -1,4 +1,4 @@
-/* Dowson Farms — Drawer Menus (accordion data, separate from DF_MENUS) */
+/* Farm Vista — Drawer Menus (accordion data, separate from DF_MENUS) */
 window.DF_DRAWER_MENUS = [
   {
     label: "Crop Production",

--- a/assets/data/footer-links.js
+++ b/assets/data/footer-links.js
@@ -1,5 +1,5 @@
 // assets/data/footer-links.js
-// Dowson Farms — Global Bottom Nav (always visible)
+// Farm Vista — Global Bottom Nav (always visible)
 // Permission-aware: if user lacks access, redirect to /access-denied.html
 
 window.DF_FOOTER_LINKS = [
@@ -38,7 +38,7 @@ window.DF_FOOTER_LINKS = [
   });
 
   // Compute active section (normalize current path vs link targets)
-  const repoBase = '/DowsonFarms/';
+  const repoBase = '/FarmVista/';
   const path = location.pathname.startsWith(repoBase)
     ? location.pathname.slice(repoBase.length)
     : location.pathname.replace(/^\//,'');

--- a/assets/data/menus.js
+++ b/assets/data/menus.js
@@ -1,4 +1,4 @@
-/* Dowson Farms — Global Navigation (one source of truth)
+/* Farm Vista — Global Navigation (one source of truth)
    Loads as a normal script and sets window.DF_MENUS.
    NOTE: All TOP-LEVEL sections use folder-style hrefs (e.g., "section/").
 */

--- a/auth/finish.html
+++ b/auth/finish.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Finish Sign-In</title>
-  <base href="/DowsonFarms/">
+  <base href="/FarmVista/">
   <style>body{font-family:system-ui,Segoe UI,Roboto,Arial;margin:24px}</style>
 </head>
 <body>
@@ -12,7 +12,7 @@
   <div id="out">Please wait…</div>
 
   <script type="module">
-    import { auth, db } from "/DowsonFarms/js/firebase-init.js";
+    import { auth, db } from "/FarmVista/js/firebase-init.js";
     import {
       isSignInWithEmailLink, signInWithEmailLink, sendPasswordResetEmail
     } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
@@ -68,7 +68,7 @@
           out.textContent = 'Signed in. (Password email not sent: ' + (e?.code||e) + '). Redirecting…';
         }
 
-        setTimeout(()=>location.href='/DowsonFarms/', 900);
+        setTimeout(()=>location.href='/FarmVista/', 900);
       }catch(e){
         out.textContent = 'Error: ' + (e?.message || e);
       }

--- a/auth/index.html
+++ b/auth/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Sign In — Dowson Farms</title>
+  <title>Sign In — Farm Vista</title>
 
   <!-- Prepaint theme (no flash) -->
   <script>
@@ -73,7 +73,7 @@
 <body>
   <main class="card" role="main">
     <div class="card__head">
-      <h1 class="card__title">Sign in to Dowson Farms</h1>
+      <h1 class="card__title">Sign in to Farm Vista</h1>
     </div>
     <div class="card__body">
       <form id="loginForm" novalidate>
@@ -97,7 +97,7 @@
         <p class="meta">Need an account? Ask an admin to invite you.</p>
         <div class="brand">
           <img src="../assets/icons/logo.png" alt="DF logo" />
-          <span>Dowson Farms</span>
+          <span>Farm Vista</span>
         </div>
       </form>
     </div>

--- a/calculators/calc-area.html
+++ b/calculators/calc-area.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Area Calculator — Dowson Farms</title>
+  <title>Area Calculator — Farm Vista</title>
   <script>
 (function () {
   var pref = localStorage.getItem('df_theme') || 'auto';
@@ -29,7 +29,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -52,7 +52,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/calculators/calc-chemical-mix.html
+++ b/calculators/calc-chemical-mix.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Chemical Mix Calculator — Dowson Farms</title>
+  <title>Chemical Mix Calculator — Farm Vista</title>
   <script>
 (function () {
   var pref = localStorage.getItem('df_theme') || 'auto';
@@ -29,7 +29,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -52,7 +52,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/calculators/calc-combine-yield.html
+++ b/calculators/calc-combine-yield.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Combine Yield Calculator — Dowson Farms</title>
+  <title>Combine Yield Calculator — Farm Vista</title>
   <script>
 (function () {
   var pref = localStorage.getItem('df_theme') || 'auto';
@@ -29,7 +29,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -52,7 +52,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/calculators/calc-grain-bin.html
+++ b/calculators/calc-grain-bin.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Grain Bin Calculator — Dowson Farms</title>
+  <title>Grain Bin Calculator — Farm Vista</title>
   <script>
 (function () {
   var pref = localStorage.getItem('df_theme') || 'auto';
@@ -29,7 +29,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -52,7 +52,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/calculators/calc-grain-shrink.html
+++ b/calculators/calc-grain-shrink.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Grain Shrink Calculator — Dowson Farms</title>
+  <title>Grain Shrink Calculator — Farm Vista</title>
   <script>
 (function () {
   var pref = localStorage.getItem('df_theme') || 'auto';
@@ -29,7 +29,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -52,7 +52,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/calculators/calc-trial-yields.html
+++ b/calculators/calc-trial-yields.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Trial Yields Calculator — Dowson Farms</title>
+  <title>Trial Yields Calculator — Farm Vista</title>
   <script>
 (function () {
   var pref = localStorage.getItem('df_theme') || 'auto';
@@ -31,7 +31,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -54,7 +54,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/calculators/index.html
+++ b/calculators/index.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Calculators — Dowson Farms</title>
+  <title>Calculators — Farm Vista</title>
 
   <!-- IMPORTANT for GitHub Pages -->
-  <base href="/DowsonFarms/">
+  <base href="/FarmVista/">
 
   <!-- Theme prepaint -->
   <script>
@@ -71,7 +71,7 @@
     <div id="tiles"></div>
   </main>
 
-  <footer>Dowson Farms App © <span id="year"></span></footer>
+  <footer>Farm Vista App © <span id="year"></span></footer>
 
   <!-- Menus (global) -->
   <script src="assets/data/menus.js?v=14"></script>

--- a/crop-production/crop-aerial.html
+++ b/crop-production/crop-aerial.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Aerial Spraying — Dowson Farms</title>
+  <title>Aerial Spraying — Farm Vista</title>
 
   <link rel="stylesheet" href="theme.css" />
   <script defer src="version.js"></script>
@@ -14,7 +14,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
@@ -35,7 +35,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/crop-production/crop-fertilizer.html
+++ b/crop-production/crop-fertilizer.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Fertilizer — Dowson Farms</title>
+  <title>Fertilizer — Farm Vista</title>
 
   <link rel="stylesheet" href="theme.css" />
   <script defer src="version.js"></script>
@@ -14,7 +14,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
@@ -35,7 +35,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/crop-production/crop-harvest.html
+++ b/crop-production/crop-harvest.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Harvest — Dowson Farms</title>
+  <title>Harvest — Farm Vista</title>
 
   <link rel="stylesheet" href="theme.css" />
   <script defer src="version.js"></script>
@@ -14,7 +14,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
@@ -35,7 +35,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/crop-production/crop-maintenance.html
+++ b/crop-production/crop-maintenance.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Field Maintenance — Dowson Farms</title>
+  <title>Field Maintenance — Farm Vista</title>
 
   <link rel="stylesheet" href="theme.css" />
   <script defer src="version.js"></script>
@@ -14,7 +14,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
@@ -35,7 +35,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/crop-production/crop-planting.html
+++ b/crop-production/crop-planting.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Planting — Dowson Farms</title>
+  <title>Planting — Farm Vista</title>
 
   <link rel="stylesheet" href="theme.css" />
   <script defer src="version.js"></script>
@@ -14,7 +14,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
@@ -35,7 +35,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/crop-production/crop-scouting.html
+++ b/crop-production/crop-scouting.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Crop Scouting — Dowson Farms</title>
+  <title>Crop Scouting — Farm Vista</title>
 
   <link rel="stylesheet" href="theme.css" />
   <script defer src="version.js"></script>
@@ -14,7 +14,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
@@ -35,7 +35,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/crop-production/crop-spraying.html
+++ b/crop-production/crop-spraying.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Spraying — Dowson Farms</title>
+  <title>Spraying — Farm Vista</title>
 
   <link rel="stylesheet" href="theme.css" />
   <script defer src="version.js"></script>
@@ -14,7 +14,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
@@ -35,7 +35,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/crop-production/crop-trials.html
+++ b/crop-production/crop-trials.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Trials — Dowson Farms</title>
+  <title>Trials — Farm Vista</title>
 
   <link rel="stylesheet" href="theme.css" />
   <script defer src="version.js"></script>
@@ -15,7 +15,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -41,7 +41,7 @@
 
   <!-- Footer -->
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/crop-production/index.html
+++ b/crop-production/index.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Crop Production — Dowson Farms</title>
+  <title>Crop Production — Farm Vista</title>
 
   <!-- GitHub Pages base (IMPORTANT) -->
-  <base href="/DowsonFarms/">
+  <base href="/FarmVista/">
 
   <!-- Theme prepaint -->
   <script>
@@ -71,7 +71,7 @@
     <div id="tiles"></div>
   </main>
 
-  <footer>Dowson Farms App © <span id="year"></span></footer>
+  <footer>Farm Vista App © <span id="year"></span></footer>
 
   <!-- Menus (global) -->
   <script src="assets/data/menus.js?v=14"></script>

--- a/equipment/equipment-combines.html
+++ b/equipment/equipment-combines.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Combines — Dowson Farms</title>
+  <title>Combines — Farm Vista</title>
   <script>
 (function () {
   var pref = localStorage.getItem('df_theme') || 'auto';
@@ -29,7 +29,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -52,7 +52,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/equipment/equipment-construction.html
+++ b/equipment/equipment-construction.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Construction — Dowson Farms</title>
+  <title>Construction — Farm Vista</title>
   <script>
 (function () {
   var pref = localStorage.getItem('df_theme') || 'auto';
@@ -29,7 +29,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -52,7 +52,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/equipment/equipment-implements.html
+++ b/equipment/equipment-implements.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Implements — Dowson Farms</title>
+  <title>Implements — Farm Vista</title>
   <script>
 (function () {
   var pref = localStorage.getItem('df_theme') || 'auto';
@@ -29,7 +29,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -52,7 +52,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/equipment/equipment-sprayers.html
+++ b/equipment/equipment-sprayers.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Sprayers / Spreaders — Dowson Farms</title>
+  <title>Sprayers / Spreaders — Farm Vista</title>
   <script>
 (function () {
   var pref = localStorage.getItem('df_theme') || 'auto';
@@ -29,7 +29,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -52,7 +52,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/equipment/equipment-starfire.html
+++ b/equipment/equipment-starfire.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Starfire / Technology — Dowson Farms</title>
+  <title>Starfire / Technology — Farm Vista</title>
   <script>
 (function () {
   var pref = localStorage.getItem('df_theme') || 'auto';
@@ -29,7 +29,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -52,7 +52,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/equipment/equipment-tractors.html
+++ b/equipment/equipment-tractors.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Tractors — Dowson Farms</title>
+  <title>Tractors — Farm Vista</title>
 
   <link rel="stylesheet" href="theme.css" />
   <script defer src="version.js"></script>
@@ -21,7 +21,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -44,7 +44,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/equipment/equipment-trailers.html
+++ b/equipment/equipment-trailers.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Trailers — Dowson Farms</title>
+  <title>Trailers — Farm Vista</title>
   <script>
 (function () {
   var pref = localStorage.getItem('df_theme') || 'auto';
@@ -29,7 +29,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -52,7 +52,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/equipment/equipment-trucks.html
+++ b/equipment/equipment-trucks.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Trucks — Dowson Farms</title>
+  <title>Trucks — Farm Vista</title>
   <script>
 (function () {
   var pref = localStorage.getItem('df_theme') || 'auto';
@@ -29,7 +29,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -52,7 +52,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/equipment/index.html
+++ b/equipment/index.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Equipment — Dowson Farms</title>
+  <title>Equipment — Farm Vista</title>
 
   <!-- GitHub Pages base (IMPORTANT) -->
-  <base href="/DowsonFarms/">
+  <base href="/FarmVista/">
 
   <!-- Theme prepaint -->
   <script>
@@ -71,7 +71,7 @@
     <div id="tiles"></div>
   </main>
 
-  <footer>Dowson Farms App © <span id="year"></span></footer>
+  <footer>Farm Vista App © <span id="year"></span></footer>
 
   <!-- Menus (global) -->
   <script src="assets/data/menus.js?v=15"></script>

--- a/feedback/bugs.html
+++ b/feedback/bugs.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Bugs / Issues — Dowson Farms</title>
+  <title>Bugs / Issues — Farm Vista</title>
 
   <!-- Prepaint theme -->
   <script>
@@ -62,7 +62,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
@@ -154,7 +154,7 @@
 
   <!-- Footer -->
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/feedback/ideas.html
+++ b/feedback/ideas.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Ideas — Dowson Farms</title>
+  <title>Ideas — Farm Vista</title>
 
   <!-- Prepaint theme (no flash) -->
   <script>
@@ -64,7 +64,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="../assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
@@ -141,7 +141,7 @@
 
   <!-- Footer (core.js injects version + date) -->
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/feedback/index.html
+++ b/feedback/index.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Feedback — Dowson Farms</title>
+  <title>Feedback — Farm Vista</title>
 
   <!-- GitHub Pages base (IMPORTANT) -->
-  <base href="/DowsonFarms/">
+  <base href="/FarmVista/">
 
   <!-- Theme prepaint -->
   <script>
@@ -71,7 +71,7 @@
     <div id="tiles"></div>
   </main>
 
-  <footer>Dowson Farms App © <span id="year"></span></footer>
+  <footer>Farm Vista App © <span id="year"></span></footer>
 
   <!-- Menus (global) -->
   <script src="assets/data/menus.js?v=16"></script>

--- a/grain-tracking/grain-bags.html
+++ b/grain-tracking/grain-bags.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Grain Bags — Dowson Farms</title>
+  <title>Grain Bags — Farm Vista</title>
   <script>
 (function () {
   var pref = localStorage.getItem('df_theme') || 'auto';
@@ -29,7 +29,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -52,7 +52,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/grain-tracking/grain-bins.html
+++ b/grain-tracking/grain-bins.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Grain Bins — Dowson Farms</title>
+  <title>Grain Bins — Farm Vista</title>
   <script>
 (function () {
   var pref = localStorage.getItem('df_theme') || 'auto';
@@ -29,7 +29,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -52,7 +52,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/grain-tracking/grain-contracts.html
+++ b/grain-tracking/grain-contracts.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Grain Contracts — Dowson Farms</title>
+  <title>Grain Contracts — Farm Vista</title>
   <script>
 (function () {
   var pref = localStorage.getItem('df_theme') || 'auto';
@@ -29,7 +29,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -52,7 +52,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/grain-tracking/grain-ticket-ocr.html
+++ b/grain-tracking/grain-ticket-ocr.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Grain Ticket (OCR) — Dowson Farms</title>
+  <title>Grain Ticket (OCR) — Farm Vista</title>
   <script>
 (function () {
   var pref = localStorage.getItem('df_theme') || 'auto';
@@ -29,7 +29,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -52,7 +52,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/grain-tracking/index.html
+++ b/grain-tracking/index.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Grain Tracking — Dowson Farms</title>
+  <title>Grain Tracking — Farm Vista</title>
 
   <!-- GitHub Pages base (IMPORTANT) -->
-  <base href="/DowsonFarms/">
+  <base href="/FarmVista/">
 
   <!-- Theme prepaint -->
   <script>
@@ -71,7 +71,7 @@
     <div id="tiles"></div>
   </main>
 
-  <footer>Dowson Farms App © <span id="year"></span></footer>
+  <footer>Farm Vista App © <span id="year"></span></footer>
 
   <!-- Menus (global) -->
   <script src="assets/data/menus.js?v=17"></script>

--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#0f5a1a" />
-  <title>Dowson Farms — Home</title>
+  <title>Farm Vista — Home</title>
 
   <!-- GitHub Pages base -->
-  <base href="/DowsonFarms/">
+  <base href="/FarmVista/">
 
   <!-- PWA -->
   <link rel="manifest" href="manifest.webmanifest" />
@@ -63,7 +63,7 @@
   <script>
     if ('serviceWorker' in navigator) {
       addEventListener('load', function () {
-        navigator.serviceWorker.register('/DowsonFarms/ServiceWorker.js', { scope: '/DowsonFarms/' })
+        navigator.serviceWorker.register('/FarmVista/ServiceWorker.js', { scope: '/FarmVista/' })
           .catch(console.warn);
       });
     }

--- a/js/access-diag.jS
+++ b/js/access-diag.jS
@@ -21,7 +21,7 @@ import { loadAccess } from "./access.js";
 
 function normBase(pathname){
   // strip repo base so it matches DF_MENUS hrefs
-  return pathname.startsWith("/DowsonFarms/") ? pathname.slice("/DowsonFarms/".length) : pathname.slice(1);
+  return pathname.startsWith("/FarmVista/") ? pathname.slice("/FarmVista/".length) : pathname.slice(1);
 }
 
 // Find the best matching rule key that applies to href

--- a/js/df-apple-icon.js
+++ b/js/df-apple-icon.js
@@ -1,6 +1,6 @@
 <script>
 /*!
-  Dowson Farms — Apple/Touch/Favicon injector
+  Farm Vista — Apple/Touch/Favicon injector
   ------------------------------------------------------------
   Purpose:
     • Guarantees the correct icons appear for “Add to Home Screen”

--- a/js/drawer.js
+++ b/js/drawer.js
@@ -83,7 +83,7 @@
     hero.innerHTML = `
       <img src="assets/icons/icon-192.png" alt="">
       <div>
-        <div style="font-weight:700">Dowson Farms</div>
+        <div style="font-weight:700">Farm Vista</div>
         <div class="mono">Divernon, Illinois</div>
       </div>
     `;
@@ -194,7 +194,7 @@
     brand.innerHTML = `
       <img src="assets/icons/icon-192.png" alt="">
       <div>
-        <div class="title">Dowson Farms · Divernon, Illinois</div>
+        <div class="title">Farm Vista · Divernon, Illinois</div>
       </div>
     `;
 

--- a/js/header.js
+++ b/js/header.js
@@ -1,10 +1,10 @@
-// Dowson Farms — Global Header (green theme)
+// Farm Vista — Global Header (green theme)
 (function () {
   const header = document.createElement("header");
   header.className = "app-header";
   header.innerHTML = `
     <button id="drawerToggle" class="burger" aria-label="Open menu">☰</button>
-    <img src="assets/icons/logo@2x.png" alt="Dowson Farms Logo" class="app-logo">
+    <img src="assets/icons/logo@2x.png" alt="Farm Vista Logo" class="app-logo">
     <div class="spacer"></div>
     <span id="dateDisplay" class="clock">--/--/----</span>
   `;

--- a/js/redirector.js
+++ b/js/redirector.js
@@ -8,5 +8,5 @@
   if (!here || here === "index.html") return;
 
   // Redirect everything else back to home
-  location.replace("/DowsonFarms/index.html");
+  location.replace("/FarmVista/index.html");
 })();

--- a/js/roles-admin.js
+++ b/js/roles-admin.js
@@ -1,5 +1,5 @@
 // roles-admin.js — simple roles CRUD + permission matrix
-import { db } from "/DowsonFarms/js/firebase-init.js";
+import { db } from "/FarmVista/js/firebase-init.js";
 import {
   collection, query, orderBy, getDocs, doc, getDoc, setDoc, deleteDoc
 } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-firestore.js";

--- a/js/subnav-check.js
+++ b/js/subnav-check.js
@@ -5,9 +5,9 @@
   // --- helpers --------------------------------------------------------------
   const baseEl = document.querySelector('base');
   const BASE = (() => {
-    if (!baseEl || !baseEl.href) return '/DowsonFarms/';
+    if (!baseEl || !baseEl.href) return '/FarmVista/';
     try { const u = new URL(baseEl.href); return u.pathname.endsWith('/') ? u.pathname : (u.pathname + '/'); }
-    catch { return '/DowsonFarms/'; }
+    catch { return '/FarmVista/'; }
   })();
 
   const stripIndex = (p) => String(p || '').replace(/index\.html$/i, '');

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,9 +1,9 @@
 {
-  "name": "Dowson Farms",
+  "name": "Farm Vista",
   "short_name": "FarmVista",
-  "description": "Dowson Farms operations",
-  "start_url": "/DowsonFarms/index.html",
-  "scope": "/DowsonFarms/",
+  "description": "Farm Vista operations",
+  "start_url": "/FarmVista/index.html",
+  "scope": "/FarmVista/",
   "display": "standalone",
   "background_color": "#0f5a1a",
   "theme_color": "#0f5a1a",

--- a/reports/index.html
+++ b/reports/index.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Reports — Dowson Farms</title>
+  <title>Reports — Farm Vista</title>
 
   <!-- GitHub Pages base (IMPORTANT) -->
-  <base href="/DowsonFarms/">
+  <base href="/FarmVista/">
 
   <!-- Theme prepaint -->
   <script>
@@ -72,7 +72,7 @@
     <p class="ai-powered-note">AI Reports are powered by ChatGPT.</p>
   </main>
 
-  <footer>Dowson Farms App © <span id="year"></span></footer>
+  <footer>Farm Vista App © <span id="year"></span></footer>
 
   <!-- Menus (global) -->
   <script src="assets/data/menus.js?v=18"></script>

--- a/reports/reports-ai-history.html
+++ b/reports/reports-ai-history.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>AI Reports History — Dowson Farms</title>
+  <title>AI Reports History — Farm Vista</title>
   <script>
 (function () {
   var pref = localStorage.getItem('df_theme') || 'auto';
@@ -29,7 +29,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -57,7 +57,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/reports/reports-ai.html
+++ b/reports/reports-ai.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>AI Reports — Dowson Farms</title>
+  <title>AI Reports — Farm Vista</title>
   <script>
   (function () {
     var pref = localStorage.getItem('df_theme') || 'auto';
@@ -29,7 +29,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -53,7 +53,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/reports/reports-predefined.html
+++ b/reports/reports-predefined.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Pre-Defined Reports — Dowson Farms</title>
+  <title>Pre-Defined Reports — Farm Vista</title>
   <script>
 (function () {
   var pref = localStorage.getItem('df_theme') || 'auto';
@@ -29,7 +29,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -52,7 +52,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/serviceworker.js
+++ b/serviceworker.js
@@ -1,20 +1,20 @@
-// Dowson Farms — minimal app-shell service worker for GitHub Pages scope /DowsonFarms/
+// Farm Vista — minimal app-shell service worker for GitHub Pages scope /FarmVista/
 const CACHE = 'df-shell-v1';
 const APP_SHELL = [
-  '/DowsonFarms/index.html',
-  '/DowsonFarms/assets/css/theme.css',
-  '/DowsonFarms/assets/css/header.css',
-  '/DowsonFarms/assets/css/drawer.css',
-  '/DowsonFarms/assets/data/menus.js',
-  '/DowsonFarms/assets/data/drawer-menus.js',
-  '/DowsonFarms/assets/data/footer-links.js',
-  '/DowsonFarms/js/header.js',
-  '/DowsonFarms/js/drawer.js',
-  '/DowsonFarms/js/footer.js',
-  '/DowsonFarms/js/version.js',
-  '/DowsonFarms/assets/icons/icon-192.png',
-  '/DowsonFarms/assets/icons/icon-512.png',
-  '/DowsonFarms/assets/icons/icon-512-maskable.png'
+  '/FarmVista/index.html',
+  '/FarmVista/assets/css/theme.css',
+  '/FarmVista/assets/css/header.css',
+  '/FarmVista/assets/css/drawer.css',
+  '/FarmVista/assets/data/menus.js',
+  '/FarmVista/assets/data/drawer-menus.js',
+  '/FarmVista/assets/data/footer-links.js',
+  '/FarmVista/js/header.js',
+  '/FarmVista/js/drawer.js',
+  '/FarmVista/js/footer.js',
+  '/FarmVista/js/version.js',
+  '/FarmVista/assets/icons/icon-192.png',
+  '/FarmVista/assets/icons/icon-512.png',
+  '/FarmVista/assets/icons/icon-512-maskable.png'
 ];
 
 self.addEventListener('install', (e) => {

--- a/settings-setup/index.html
+++ b/settings-setup/index.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Dowson Farms — Settings & Setup</title>
+  <title>Farm Vista — Settings & Setup</title>
 
   <!-- Root base for GitHub Pages -->
-  <base href="/DowsonFarms/">
+  <base href="/FarmVista/">
 
   <!-- Theme prepaint (same as Teams) -->
   <script>
@@ -78,7 +78,7 @@
     </section>
   </main>
 
-  <footer>Dowson Farms App © <span id="year"></span></footer>
+  <footer>Farm Vista App © <span id="year"></span></footer>
 
   <!-- ───────────── SCRIPTS (order matches your working pattern) ───────────── -->
 
@@ -115,7 +115,7 @@
         msg.textContent = "Checking…";
         try {
           if ('serviceWorker' in navigator) {
-            const reg = await navigator.serviceWorker.getRegistration('/DowsonFarms/serviceworker.js') ||
+            const reg = await navigator.serviceWorker.getRegistration('/FarmVista/serviceworker.js') ||
                         await navigator.serviceWorker.getRegistration();
             if (reg && reg.update) await reg.update();
           }

--- a/settings-setup/products/index.html
+++ b/settings-setup/products/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Products — Dowson Farms</title>
+  <title>Products — Farm Vista</title>
 
   <!-- Prepaint theme (no flash) -->
   <script>
@@ -37,7 +37,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="../../assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
@@ -68,7 +68,7 @@
 
   <!-- Footer -->
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/settings-setup/products/products-chemical.html
+++ b/settings-setup/products/products-chemical.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Chemical — Dowson Farms</title>
+  <title>Chemical — Farm Vista</title>
 
   <!-- Prepaint theme -->
   <script>
@@ -33,7 +33,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
@@ -61,7 +61,7 @@
 
   <!-- Footer -->
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/settings-setup/products/products-fertilizer.html
+++ b/settings-setup/products/products-fertilizer.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Fertilizer — Dowson Farms</title>
+  <title>Fertilizer — Farm Vista</title>
 
   <!-- Prepaint theme -->
   <script>
@@ -33,7 +33,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
@@ -61,7 +61,7 @@
 
   <!-- Footer -->
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/settings-setup/products/products-grain-bags.html
+++ b/settings-setup/products/products-grain-bags.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Grain Bags — Dowson Farms</title>
+  <title>Grain Bags — Farm Vista</title>
 
   <!-- Prepaint theme -->
   <script>
@@ -33,7 +33,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
@@ -61,7 +61,7 @@
 
   <!-- Footer -->
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/settings-setup/products/products-seed.html
+++ b/settings-setup/products/products-seed.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Seed — Dowson Farms</title>
+  <title>Seed — Farm Vista</title>
 
   <!-- Prepaint theme -->
   <script>
@@ -38,7 +38,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
@@ -66,7 +66,7 @@
 
   <!-- Footer -->
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/settings-setup/ss-crop-types.html
+++ b/settings-setup/ss-crop-types.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Crop Types — Dowson Farms</title>
+  <title>Crop Types — Farm Vista</title>
 
   <!-- GitHub Pages base (IMPORTANT for all relative paths) -->
-  <base href="/DowsonFarms/">
+  <base href="/FarmVista/">
 
   <!-- Theme prepaint to avoid flash -->
   <script>
@@ -118,7 +118,7 @@
     </section>
   </main>
 
-  <footer>Dowson Farms App © <span id="year"></span></footer>
+  <footer>Farm Vista App © <span id="year"></span></footer>
   <div id="dfToast" class="toast"><span id="dfToastText">Saved</span></div>
 
   <!-- ───────── SCRIPTS (order matters) ───────── -->

--- a/settings-setup/ss-farms.html
+++ b/settings-setup/ss-farms.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Farms — Dowson Farms</title>
+  <title>Farms — Farm Vista</title>
   <script>
   (function () {
     var pref = localStorage.getItem('df_theme') || 'auto';
@@ -28,7 +28,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
@@ -79,7 +79,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/settings-setup/ss-fields.html
+++ b/settings-setup/ss-fields.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Fields — Dowson Farms</title>
+  <title>Fields — Farm Vista</title>
   <script>
   (function () {
     var pref = localStorage.getItem('df_theme') || 'auto';
@@ -35,7 +35,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
@@ -122,7 +122,7 @@
   </main>
 
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/settings-setup/ss-roles.html
+++ b/settings-setup/ss-roles.html
@@ -6,7 +6,7 @@
   <title>Account Roles</title>
 
   <!-- GitHub Pages base -->
-  <base href="/DowsonFarms/">
+  <base href="/FarmVista/">
 
   <link rel="stylesheet" href="assets/css/theme.css" />
   <style>

--- a/settings-setup/ss-theme.html
+++ b/settings-setup/ss-theme.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Theme — Dowson Farms</title>
+  <title>Theme — Farm Vista</title>
 
   <!-- Prepaint theme (single, consolidated) -->
   <script>
@@ -61,7 +61,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">
       <span id="clock" class="clock">--:--</span>
@@ -113,7 +113,7 @@
 
   <!-- Footer -->
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/teams-partners/index.html
+++ b/teams-partners/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Dowson Farms — Teams & Partners</title>
+  <title>Farm Vista — Teams & Partners</title>
 
-  <base href="/DowsonFarms/">
+  <base href="/FarmVista/">
 
   <script>
     (function () {
@@ -63,7 +63,7 @@
     <div id="tiles"></div>
   </main>
 
-  <footer>Dowson Farms App © <span id="year"></span></footer>
+  <footer>Farm Vista App © <span id="year"></span></footer>
 
   <!-- 1) menus -->
   <script src="assets/data/menus.js"></script>

--- a/teams-partners/teams-dictionary.html
+++ b/teams-partners/teams-dictionary.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Dictionary — Dowson Farms</title>
+  <title>Dictionary — Farm Vista</title>
 
   <!-- Prepaint theme -->
   <script>
@@ -34,7 +34,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="../assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
@@ -71,7 +71,7 @@
 
   <!-- Footer -->
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/teams-partners/teams-employees.html
+++ b/teams-partners/teams-employees.html
@@ -6,7 +6,7 @@
   <title>Employees</title>
 
   <!-- IMPORTANT for GitHub Pages paths -->
-  <base href="/DowsonFarms/">
+  <base href="/FarmVista/">
 
   <link rel="stylesheet" href="assets/css/theme.css" />
   <style>

--- a/teams-partners/teams-sub-contractors.html
+++ b/teams-partners/teams-sub-contractors.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Sub-Contractors — Dowson Farms</title>
+  <title>Sub-Contractors — Farm Vista</title>
 
   <!-- Prepaint theme -->
   <script>
@@ -70,7 +70,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="../assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
@@ -175,7 +175,7 @@
 
   <!-- Footer -->
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>

--- a/teams-partners/teams-vendors.html
+++ b/teams-partners/teams-vendors.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#1B5E20" />
-  <title>Vendors — Dowson Farms</title>
+  <title>Vendors — Farm Vista</title>
 
   <!-- Prepaint theme -->
   <script>
@@ -45,7 +45,7 @@
   <header class="app-header">
     <div class="app-header__left">
       <img src="../assets/icons/icon-192.png" alt="Logo" class="app-logo" />
-      <div class="app-header__title">Dowson Farms</div>
+      <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
@@ -134,7 +134,7 @@
 
   <!-- Footer -->
   <footer class="app-footer">
-    <span>Dowson Farms</span>
+    <span>Farm Vista</span>
     <span class="dot">•</span>
     <span id="report-date">—</span>
     <span class="dot">•</span>


### PR DESCRIPTION
## Summary
- replace Dowson Farms branding with Farm Vista across HTML, JS, and CSS assets
- update GitHub Pages base URLs, service worker assets, and manifest scope to the new /FarmVista/ path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dff9dbd1d48321938ca116f3ce30b4