### PR TITLE
Update Apple touch icon references

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,10 +15,10 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 
   <!-- Apple Touch Icons (FarmVista set) -->
-  <link rel="apple-touch-icon" sizes="120x120" href="assets/icons/farmvista-apple-touch-icon-120.png" />
-  <link rel="apple-touch-icon" sizes="152x152" href="assets/icons/farmvista-apple-touch-icon-152.png" />
-  <link rel="apple-touch-icon" sizes="167x167" href="assets/icons/farmvista-apple-touch-icon-167.png" />
-  <link rel="apple-touch-icon" sizes="180x180" href="assets/icons/farmvista-apple-touch-icon-180.png" />
+  <link rel="apple-touch-icon" sizes="120x120" href="assets/icons/FarmVista-apple-touch-icon-120x120.png" />
+  <link rel="apple-touch-icon" sizes="152x152" href="assets/icons/FarmVista-apple-touch-icon-152x152.png" />
+  <link rel="apple-touch-icon" sizes="167x167" href="assets/icons/FarmVista-apple-touch-icon-167x167.png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="assets/icons/FarmVista-apple-touch-icon-180x180.png" />
 
   <!-- Prepaint theme (unchanged) -->
   <script>


### PR DESCRIPTION
## Summary
- fix the Apple touch icon links in index.html to use the FarmVista icon set

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dffe39a47c8321bb4a69698e9d5de6