### PR TITLE
Point headers to Farm Vista logo asset

### DIFF
--- a/access-denied.html
+++ b/access-denied.html
@@ -39,7 +39,7 @@
 </head>
 <body>
   <header>
-    <img src="assets/icons/icon-192.png" alt="Logo">
+    <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo">
     <div class="title">Farm Vista</div>
   </header>
 

--- a/auth/index.html
+++ b/auth/index.html
@@ -217,7 +217,7 @@
   <main class="card" role="main">
     <div class="card__head">
       <div class="brand-lockup" aria-label="Farm Vista for Dowson Farms">
-        <img src="../assets/icons/logo.png" alt="Farm Vista" />
+        <img src="../assets/icons/Farm_Vista_Logo.png" alt="Farm Vista" />
         <span>Farm Vista <small>for Dowson Farms</small></span>
       </div>
       <h1 class="card__title">Welcome back to your fields</h1>

--- a/calculators/calc-area.html
+++ b/calculators/calc-area.html
@@ -28,7 +28,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/calculators/calc-chemical-mix.html
+++ b/calculators/calc-chemical-mix.html
@@ -28,7 +28,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/calculators/calc-combine-yield.html
+++ b/calculators/calc-combine-yield.html
@@ -28,7 +28,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/calculators/calc-grain-bin.html
+++ b/calculators/calc-grain-bin.html
@@ -28,7 +28,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/calculators/calc-grain-shrink.html
+++ b/calculators/calc-grain-shrink.html
@@ -28,7 +28,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/calculators/calc-trial-yields.html
+++ b/calculators/calc-trial-yields.html
@@ -30,7 +30,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/crop-production/crop-aerial.html
+++ b/crop-production/crop-aerial.html
@@ -13,7 +13,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>

--- a/crop-production/crop-fertilizer.html
+++ b/crop-production/crop-fertilizer.html
@@ -13,7 +13,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>

--- a/crop-production/crop-harvest.html
+++ b/crop-production/crop-harvest.html
@@ -13,7 +13,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>

--- a/crop-production/crop-maintenance.html
+++ b/crop-production/crop-maintenance.html
@@ -13,7 +13,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>

--- a/crop-production/crop-planting.html
+++ b/crop-production/crop-planting.html
@@ -13,7 +13,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>

--- a/crop-production/crop-scouting.html
+++ b/crop-production/crop-scouting.html
@@ -13,7 +13,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>

--- a/crop-production/crop-spraying.html
+++ b/crop-production/crop-spraying.html
@@ -13,7 +13,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>

--- a/crop-production/crop-trials.html
+++ b/crop-production/crop-trials.html
@@ -14,7 +14,7 @@
   <!-- Header -->
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/equipment/equipment-combines.html
+++ b/equipment/equipment-combines.html
@@ -28,7 +28,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/equipment/equipment-construction.html
+++ b/equipment/equipment-construction.html
@@ -28,7 +28,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/equipment/equipment-implements.html
+++ b/equipment/equipment-implements.html
@@ -28,7 +28,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/equipment/equipment-sprayers.html
+++ b/equipment/equipment-sprayers.html
@@ -28,7 +28,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/equipment/equipment-starfire.html
+++ b/equipment/equipment-starfire.html
@@ -28,7 +28,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/equipment/equipment-tractors.html
+++ b/equipment/equipment-tractors.html
@@ -20,7 +20,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/equipment/equipment-trailers.html
+++ b/equipment/equipment-trailers.html
@@ -28,7 +28,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/equipment/equipment-trucks.html
+++ b/equipment/equipment-trucks.html
@@ -28,7 +28,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/feedback/bugs.html
+++ b/feedback/bugs.html
@@ -61,7 +61,7 @@
   <!-- Header -->
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>

--- a/feedback/ideas.html
+++ b/feedback/ideas.html
@@ -63,7 +63,7 @@
   <!-- Header (core.js handles logout, clock, etc.) -->
   <header class="app-header">
     <div class="app-header__left">
-      <img src="../assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="../assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>

--- a/grain-tracking/grain-bags.html
+++ b/grain-tracking/grain-bags.html
@@ -28,7 +28,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/grain-tracking/grain-bins.html
+++ b/grain-tracking/grain-bins.html
@@ -28,7 +28,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/grain-tracking/grain-contracts.html
+++ b/grain-tracking/grain-contracts.html
@@ -28,7 +28,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/grain-tracking/grain-ticket-ocr.html
+++ b/grain-tracking/grain-ticket-ocr.html
@@ -28,7 +28,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/reports/reports-ai-history.html
+++ b/reports/reports-ai-history.html
@@ -28,7 +28,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/reports/reports-ai.html
+++ b/reports/reports-ai.html
@@ -28,7 +28,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/reports/reports-predefined.html
+++ b/reports/reports-predefined.html
@@ -28,7 +28,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/settings-setup/products/index.html
+++ b/settings-setup/products/index.html
@@ -36,7 +36,7 @@
   <!-- Header -->
   <header class="app-header">
     <div class="app-header__left">
-      <img src="../../assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="../../assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>

--- a/settings-setup/products/products-chemical.html
+++ b/settings-setup/products/products-chemical.html
@@ -32,7 +32,7 @@
   <!-- Header -->
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>

--- a/settings-setup/products/products-fertilizer.html
+++ b/settings-setup/products/products-fertilizer.html
@@ -32,7 +32,7 @@
   <!-- Header -->
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>

--- a/settings-setup/products/products-grain-bags.html
+++ b/settings-setup/products/products-grain-bags.html
@@ -32,7 +32,7 @@
   <!-- Header -->
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>

--- a/settings-setup/products/products-seed.html
+++ b/settings-setup/products/products-seed.html
@@ -37,7 +37,7 @@
   <!-- Header -->
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>

--- a/settings-setup/ss-farms.html
+++ b/settings-setup/ss-farms.html
@@ -27,7 +27,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>

--- a/settings-setup/ss-fields.html
+++ b/settings-setup/ss-fields.html
@@ -34,7 +34,7 @@
 <body>
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>

--- a/settings-setup/ss-theme.html
+++ b/settings-setup/ss-theme.html
@@ -60,7 +60,7 @@
   <!-- Header -->
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right">

--- a/teams-partners/teams-dictionary.html
+++ b/teams-partners/teams-dictionary.html
@@ -33,7 +33,7 @@
   <!-- Header -->
   <header class="app-header">
     <div class="app-header__left">
-      <img src="../assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="../assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>

--- a/teams-partners/teams-sub-contractors.html
+++ b/teams-partners/teams-sub-contractors.html
@@ -69,7 +69,7 @@
   <!-- Header -->
   <header class="app-header">
     <div class="app-header__left">
-      <img src="../assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="../assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>

--- a/teams-partners/teams-vendors.html
+++ b/teams-partners/teams-vendors.html
@@ -44,7 +44,7 @@
   <!-- Header -->
   <header class="app-header">
     <div class="app-header__left">
-      <img src="../assets/icons/icon-192.png" alt="Logo" class="app-logo" />
+      <img src="../assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>


### PR DESCRIPTION
## Summary
- update header brand images across access denied, calculators, crop production, equipment, feedback, grain tracking, reports, settings, teams, and auth pages
- ensure each page references the Farm Vista logo stored at assets/icons/Farm_Vista_Logo.png

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e03ff03a2883218a1b900d023c702a