### PR TITLE
Refine global header layout

### DIFF
--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -47,16 +47,47 @@ body { padding-top: var(--fv-header-height); }
   border-color: rgba(251, 249, 240, 0.55);
 }
 
-.app-header img.app-logo {
-  height: 58px;
-  width: auto;
-  display: block;
-  object-fit: contain;
-  max-width: 45vw;
-  filter: drop-shadow(0 8px 20px rgba(23, 52, 49, 0.32));
+.app-header .header-breadcrumbs {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
 }
 
-.app-header .spacer { flex: 1; }
+.app-header img.app-logo {
+  display: none !important;
+}
+
+.app-header .header-breadcrumbs:empty {
+  display: none;
+}
+
+.app-header nav.breadcrumbs.in-app-header {
+  padding: 0;
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(254, 252, 244, 0.82);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.app-header nav.breadcrumbs.in-app-header ol {
+  gap: 8px;
+  flex-wrap: nowrap;
+}
+
+.app-header nav.breadcrumbs.in-app-header li {
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.app-header nav.breadcrumbs.in-app-header a {
+  color: #fefcf4;
+}
+
+.app-header nav.breadcrumbs.in-app-header .sep {
+  opacity: 0.55;
+}
 
 .app-header .clock {
   color: rgba(254, 252, 244, 0.85);
@@ -64,6 +95,7 @@ body { padding-top: var(--fv-header-height); }
   font-variant-numeric: tabular-nums;
   letter-spacing: 0.02em;
   text-align: right;
+  margin-left: auto;
 }
 
 .app-header a {
@@ -78,16 +110,10 @@ body { padding-top: var(--fv-header-height); }
     gap: 10px;
     padding: 0 14px;
   }
-  .app-header img.app-logo {
-    height: 50px;
-  }
 }
 
 @media (max-width: 360px) {
   .app-header {
     padding: 0 10px;
-  }
-  .app-header img.app-logo {
-    height: 42px;
   }
 }

--- a/js/header.js
+++ b/js/header.js
@@ -4,11 +4,19 @@
   header.className = "app-header";
   header.innerHTML = `
     <button id="drawerToggle" class="burger" aria-label="Open menu">☰</button>
-    <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista" class="app-logo">
-    <div class="spacer"></div>
+    <div class="header-breadcrumbs" role="presentation"></div>
     <span id="dateDisplay" class="clock">--/--/----</span>
   `;
   document.body.prepend(header);
+
+  const breadcrumbHost = header.querySelector(".header-breadcrumbs");
+  const pageBreadcrumbs = document.querySelector("nav.breadcrumbs");
+  if (pageBreadcrumbs && !header.contains(pageBreadcrumbs)) {
+    pageBreadcrumbs.classList.add("in-app-header");
+    breadcrumbHost.appendChild(pageBreadcrumbs);
+  } else {
+    breadcrumbHost.remove();
+  }
 
   // Date display (Central Time)
   const dateEl = header.querySelector("#dateDisplay");


### PR DESCRIPTION
## Summary
- move page breadcrumbs into the injected global header and remove the logo so the layout matches the new direction
- style the header breadcrumbs to stay left-aligned while keeping the date pinned on the right across viewports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e056f531648321bb0aa8881d34f5d5