### PR TITLE
Refine login spacing and show loading overlay

### DIFF
--- a/auth/index.html
+++ b/auth/index.html
@@ -106,9 +106,14 @@
       padding:24px 28px 32px;
       display:flex;
       flex-direction:column;
-      gap:18px;
+      gap:22px;
     }
-    .field { display:flex; flex-direction:column; gap:6px; }
+    #loginForm {
+      display:flex;
+      flex-direction:column;
+      gap:20px;
+    }
+    .field { display:flex; flex-direction:column; gap:8px; }
     label { font-size:14px; font-weight:600; color:rgba(20, 50, 49, 0.78); }
     input {
       width:100%;
@@ -185,16 +190,16 @@
     }
     .btn {
       width:100%;
-      padding:15px 18px;
+      padding:12px 18px;
       border:0;
-      border-radius:18px;
+      border-radius:16px;
       cursor:pointer;
       background:linear-gradient(135deg, var(--brand-blue), #688874);
       color:#fff;
-      font-weight:700;
-      font-size:17px;
-      letter-spacing:0.01em;
-      box-shadow:0 12px 20px rgba(54, 94, 90, 0.24);
+      font-weight:600;
+      font-size:16px;
+      letter-spacing:0.005em;
+      box-shadow:0 10px 18px rgba(54, 94, 90, 0.2);
       transition:transform .15s ease, box-shadow .15s ease;
     }
     .btn:focus-visible {

--- a/js/auth.js
+++ b/js/auth.js
@@ -6,6 +6,7 @@ import {
   signInWithEmailAndPassword
 } from "https://www.gstatic.com/firebasejs/10.13.0/firebase-auth.js";
 import { auth } from "./firebase-init.js";
+import { showWait, hideWait } from "./wait-overlay.js";
 
 // If already signed in, bounce to app home
 onAuthStateChanged(auth, (user) => {
@@ -39,7 +40,7 @@ toggle.addEventListener("click", (e) => {
 
 form.addEventListener("submit", async (e) => {
   e.preventDefault();
-  showMsg("Signing in…", "info");
+  showMsg("");
 
   const email = emailEl.value.trim();
   const pw    = passEl.value;
@@ -49,10 +50,14 @@ form.addEventListener("submit", async (e) => {
     return;
   }
 
+  showWait("Please wait… Loading");
+
   try {
     await signInWithEmailAndPassword(auth, email, pw);
     // onAuthStateChanged handles redirect
   } catch (err) {
+    hideWait(0);
+
     let friendly = "Sign-in failed. ";
     switch (err.code) {
       case "auth/invalid-email":     friendly += "Invalid email."; break;


### PR DESCRIPTION
## Summary
- adjust login form spacing and button styling for a lighter layout
- reuse the global wait overlay on sign-in to show the branded loading spinner

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e05c5f02408321a3db2bc8604a5473