### PR TITLE
Update drawer footer to scroll with sidebar content

### DIFF
--- a/assets/css/drawer.css
+++ b/assets/css/drawer.css
@@ -14,7 +14,7 @@
 }
 body.drawer-open .drawerBackdrop{ opacity:1; visibility:visible; }
 
-/* Panel (flex column so footer can sit at bottom) */
+/* Panel (flex column so scroll area can expand) */
 .drawer{
   --drawer-w: 320px;                   /* JS may override this inline */
   position:fixed; inset:var(--fv-header-height, 68px) auto 0 0; width:var(--drawer-w); max-width:86vw;
@@ -27,6 +27,15 @@ body.drawer-open .drawerBackdrop{ opacity:1; visibility:visible; }
   border-radius: 0 var(--drawer-radius) var(--drawer-radius) 0;
 }
 body.drawer-open .drawer{ translate:0 0; }
+
+/* Scroll region: includes hero, nav, and footer */
+.drawerScroll{
+  flex:1 1 auto;
+  display:flex;
+  flex-direction:column;
+  overflow-y:auto;
+  overflow-x:hidden;
+}
 
 /* ===== Top hero (uses the “dead space”) ===== */
 .drawer .hero{
@@ -49,11 +58,10 @@ body.drawer-open .drawer{ translate:0 0; }
   font:13px/1.2 "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Arial, "Noto Sans";
 }
 
-/* List area (scrolls) */
+/* List area */
 .drawer nav{
   padding:6px;
-  overflow:auto;
-  flex:1 1 auto;
+  flex:0 0 auto;
 }
 
 /* Shared metrics */
@@ -111,12 +119,14 @@ body.drawer-open .drawer{ translate:0 0; }
 .drawer .subgroup[aria-expanded="true"] .subpanel{ max-height:900px; }
 .drawer .subgroup[aria-expanded="true"] .chev{ transform:rotate(90deg); }
 
-/* ===== Footer block — pinned flush to bottom, no tall banner ===== */
+/* ===== Footer block — part of scroll flow ===== */
 .drawerFooter{
-  position:sticky; bottom:0;
   background:rgba(248, 245, 230, 0.95);
-  padding:10px 10px 14px;
+  padding:12px 10px 18px;
   border-top:1px solid rgba(20, 50, 49, 0.1);
+  margin:10px 6px 18px;
+  border-radius:18px;
+  box-shadow:0 16px 26px rgba(23, 52, 49, 0.08);
 }
 
 /* Logout row — same size/feel as a normal item */

--- a/js/drawer.js
+++ b/js/drawer.js
@@ -1,4 +1,4 @@
-// js/drawer.js — robust hamburger + hero + sticky footer
+// js/drawer.js — robust hamburger + hero + scrolling footer
 // - Auto-creates #drawer and #drawerBackdrop if missing.
 // - Works with injected header (delegation + retry).
 // - Builds accordion from DF_DRAWER_MENUS.
@@ -221,10 +221,14 @@
 
   // ---------- assemble structure ----------
   const navShell = drawer.querySelector("nav") || document.createElement("nav");
+  const scrollWrap = document.createElement("div");
+  scrollWrap.className = "drawerScroll";
+
   drawer.innerHTML = "";
-  drawer.appendChild(buildHero());
-  drawer.appendChild(navShell);
-  drawer.appendChild(buildFooter());
+  scrollWrap.appendChild(buildHero());
+  scrollWrap.appendChild(navShell);
+  scrollWrap.appendChild(buildFooter());
+  drawer.appendChild(scrollWrap);
 
   // ---------- build accordion ----------
   const nav = navShell;


### PR DESCRIPTION
## Summary
- wrap the drawer hero, navigation, and footer inside a shared scroll container so every section scrolls together
- refresh drawer styles to use the new scroll area and treat the footer as part of the scrollable flow

## Testing
- Manual - opened the app in a browser and confirmed the drawer footer scrolls with the rest of the menu

------
https://chatgpt.com/codex/tasks/task_e_68e06f0f036c83218175ae0a71564064