### PR TITLE
Standardize crop production module placeholders

### DIFF
--- a/crop-production/crop-aerial.html
+++ b/crop-production/crop-aerial.html
@@ -6,34 +6,80 @@
   <meta name="theme-color" content="#365E5A" />
   <title>Aerial Spraying — Farm Vista</title>
 
+  <!-- Prepaint theme -->
+  <script>
+  (function () {
+    var pref = localStorage.getItem('df_theme') || 'auto';
+    var dark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-theme', pref === 'auto' ? (dark ? 'dark' : 'light') : pref);
+    document.documentElement.style.colorScheme =
+      (pref === 'auto' ? (dark ? 'dark' : 'light') : pref) === 'dark' ? 'dark' : 'light';
+  })();
+  </script>
+
+  <!-- Global styles + app scripts -->
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
-  <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/version.js"></script>
+  <script defer src="../js/core.js"></script>
+
+  <!-- Page-only styles -->
+  <style>
+    .coming {
+      display:flex;
+      flex-direction:column;
+      align-items:center;
+      justify-content:center;
+      gap:10px;
+      padding:26px;
+      text-align:center;
+    }
+
+    .coming .emoji {
+      font-size:44px;
+      line-height:1;
+    }
+
+    .coming .title {
+      font-weight:800;
+      font-size:1.2rem;
+    }
+
+    .coming .hint {
+      opacity:.8;
+    }
+  </style>
 </head>
 <body>
+  <!-- Header -->
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
+      <img src="../assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
 
+  <!-- Breadcrumbs -->
   <nav class="breadcrumbs" aria-label="Breadcrumb">
     <ol>
-      <li><a href="index.html">Home</a></li>
+      <li><a href="../index.html">Home</a></li>
       <li class="sep">›</li>
-      <li><a href="crop.html">Crop Production</a></li>
+      <li><a href="index.html">Crop Production</a></li>
       <li class="sep">›</li>
       <li><span>Aerial Spraying</span></li>
     </ol>
   </nav>
 
+  <!-- Main content -->
   <main class="content">
-    <h1>🚁 Aerial Spraying</h1>
-    <p>🚧 Coming soon…</p>
+    <section class="card coming">
+      <div class="emoji">🚁</div>
+      <div class="title">Aerial Spraying — Coming Soon</div>
+      <div class="hint">Coordinate aerial passes and product details.</div>
+    </section>
   </main>
 
+  <!-- Footer -->
   <footer class="app-footer">
     <span>Farm Vista</span>
     <span class="dot">•</span>
@@ -41,5 +87,13 @@
     <span class="dot">•</span>
     <span id="version">v0.0.0</span>
   </footer>
+
+  <script>
+    if ("serviceWorker" in navigator) {
+      window.addEventListener("load", () => {
+        navigator.serviceWorker.register("../serviceworker.js").catch(console.error);
+      });
+    }
+  </script>
 </body>
 </html>

--- a/crop-production/crop-fertilizer.html
+++ b/crop-production/crop-fertilizer.html
@@ -6,34 +6,80 @@
   <meta name="theme-color" content="#365E5A" />
   <title>Fertilizer — Farm Vista</title>
 
+  <!-- Prepaint theme -->
+  <script>
+  (function () {
+    var pref = localStorage.getItem('df_theme') || 'auto';
+    var dark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-theme', pref === 'auto' ? (dark ? 'dark' : 'light') : pref);
+    document.documentElement.style.colorScheme =
+      (pref === 'auto' ? (dark ? 'dark' : 'light') : pref) === 'dark' ? 'dark' : 'light';
+  })();
+  </script>
+
+  <!-- Global styles + app scripts -->
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
-  <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/version.js"></script>
+  <script defer src="../js/core.js"></script>
+
+  <!-- Page-only styles -->
+  <style>
+    .coming {
+      display:flex;
+      flex-direction:column;
+      align-items:center;
+      justify-content:center;
+      gap:10px;
+      padding:26px;
+      text-align:center;
+    }
+
+    .coming .emoji {
+      font-size:44px;
+      line-height:1;
+    }
+
+    .coming .title {
+      font-weight:800;
+      font-size:1.2rem;
+    }
+
+    .coming .hint {
+      opacity:.8;
+    }
+  </style>
 </head>
 <body>
+  <!-- Header -->
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
+      <img src="../assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
 
+  <!-- Breadcrumbs -->
   <nav class="breadcrumbs" aria-label="Breadcrumb">
     <ol>
-      <li><a href="index.html">Home</a></li>
+      <li><a href="../index.html">Home</a></li>
       <li class="sep">›</li>
-      <li><a href="crop.html">Crop Production</a></li>
+      <li><a href="index.html">Crop Production</a></li>
       <li class="sep">›</li>
       <li><span>Fertilizer</span></li>
     </ol>
   </nav>
 
+  <!-- Main content -->
   <main class="content">
-    <h1>🧪 Fertilizer</h1>
-    <p>🚧 Coming soon…</p>
+    <section class="card coming">
+      <div class="emoji">🧪</div>
+      <div class="title">Fertilizer — Coming Soon</div>
+      <div class="hint">Blend recipes, rates, and coverage tracking.</div>
+    </section>
   </main>
 
+  <!-- Footer -->
   <footer class="app-footer">
     <span>Farm Vista</span>
     <span class="dot">•</span>
@@ -41,5 +87,13 @@
     <span class="dot">•</span>
     <span id="version">v0.0.0</span>
   </footer>
+
+  <script>
+    if ("serviceWorker" in navigator) {
+      window.addEventListener("load", () => {
+        navigator.serviceWorker.register("../serviceworker.js").catch(console.error);
+      });
+    }
+  </script>
 </body>
 </html>

--- a/crop-production/crop-harvest.html
+++ b/crop-production/crop-harvest.html
@@ -6,34 +6,80 @@
   <meta name="theme-color" content="#365E5A" />
   <title>Harvest — Farm Vista</title>
 
+  <!-- Prepaint theme -->
+  <script>
+  (function () {
+    var pref = localStorage.getItem('df_theme') || 'auto';
+    var dark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-theme', pref === 'auto' ? (dark ? 'dark' : 'light') : pref);
+    document.documentElement.style.colorScheme =
+      (pref === 'auto' ? (dark ? 'dark' : 'light') : pref) === 'dark' ? 'dark' : 'light';
+  })();
+  </script>
+
+  <!-- Global styles + app scripts -->
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
-  <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/version.js"></script>
+  <script defer src="../js/core.js"></script>
+
+  <!-- Page-only styles -->
+  <style>
+    .coming {
+      display:flex;
+      flex-direction:column;
+      align-items:center;
+      justify-content:center;
+      gap:10px;
+      padding:26px;
+      text-align:center;
+    }
+
+    .coming .emoji {
+      font-size:44px;
+      line-height:1;
+    }
+
+    .coming .title {
+      font-weight:800;
+      font-size:1.2rem;
+    }
+
+    .coming .hint {
+      opacity:.8;
+    }
+  </style>
 </head>
 <body>
+  <!-- Header -->
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
+      <img src="../assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
 
+  <!-- Breadcrumbs -->
   <nav class="breadcrumbs" aria-label="Breadcrumb">
     <ol>
-      <li><a href="index.html">Home</a></li>
+      <li><a href="../index.html">Home</a></li>
       <li class="sep">›</li>
-      <li><a href="crop.html">Crop Production</a></li>
+      <li><a href="index.html">Crop Production</a></li>
       <li class="sep">›</li>
       <li><span>Harvest</span></li>
     </ol>
   </nav>
 
+  <!-- Main content -->
   <main class="content">
-    <h1>🌾 Harvest</h1>
-    <p>🚧 Coming soon…</p>
+    <section class="card coming">
+      <div class="emoji">🌾</div>
+      <div class="title">Harvest — Coming Soon</div>
+      <div class="hint">Track combine assignments and unload destinations.</div>
+    </section>
   </main>
 
+  <!-- Footer -->
   <footer class="app-footer">
     <span>Farm Vista</span>
     <span class="dot">•</span>
@@ -41,5 +87,13 @@
     <span class="dot">•</span>
     <span id="version">v0.0.0</span>
   </footer>
+
+  <script>
+    if ("serviceWorker" in navigator) {
+      window.addEventListener("load", () => {
+        navigator.serviceWorker.register("../serviceworker.js").catch(console.error);
+      });
+    }
+  </script>
 </body>
 </html>

--- a/crop-production/crop-maintenance.html
+++ b/crop-production/crop-maintenance.html
@@ -4,36 +4,82 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#365E5A" />
-  <title>Field Maintenance — Farm Vista</title>
+  <title>Maintenance — Farm Vista</title>
 
+  <!-- Prepaint theme -->
+  <script>
+  (function () {
+    var pref = localStorage.getItem('df_theme') || 'auto';
+    var dark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-theme', pref === 'auto' ? (dark ? 'dark' : 'light') : pref);
+    document.documentElement.style.colorScheme =
+      (pref === 'auto' ? (dark ? 'dark' : 'light') : pref) === 'dark' ? 'dark' : 'light';
+  })();
+  </script>
+
+  <!-- Global styles + app scripts -->
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
-  <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/version.js"></script>
+  <script defer src="../js/core.js"></script>
+
+  <!-- Page-only styles -->
+  <style>
+    .coming {
+      display:flex;
+      flex-direction:column;
+      align-items:center;
+      justify-content:center;
+      gap:10px;
+      padding:26px;
+      text-align:center;
+    }
+
+    .coming .emoji {
+      font-size:44px;
+      line-height:1;
+    }
+
+    .coming .title {
+      font-weight:800;
+      font-size:1.2rem;
+    }
+
+    .coming .hint {
+      opacity:.8;
+    }
+  </style>
 </head>
 <body>
+  <!-- Header -->
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
+      <img src="../assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
 
+  <!-- Breadcrumbs -->
   <nav class="breadcrumbs" aria-label="Breadcrumb">
     <ol>
-      <li><a href="index.html">Home</a></li>
+      <li><a href="../index.html">Home</a></li>
       <li class="sep">›</li>
-      <li><a href="crop.html">Crop Production</a></li>
+      <li><a href="index.html">Crop Production</a></li>
       <li class="sep">›</li>
-      <li><span>Field Maintenance</span></li>
+      <li><span>Maintenance</span></li>
     </ol>
   </nav>
 
+  <!-- Main content -->
   <main class="content">
-    <h1>🛠️ Field Maintenance</h1>
-    <p>🚧 Coming soon…</p>
+    <section class="card coming">
+      <div class="emoji">🛠️</div>
+      <div class="title">Maintenance — Coming Soon</div>
+      <div class="hint">Keep planters, sprayers, and tools field-ready.</div>
+    </section>
   </main>
 
+  <!-- Footer -->
   <footer class="app-footer">
     <span>Farm Vista</span>
     <span class="dot">•</span>
@@ -41,5 +87,13 @@
     <span class="dot">•</span>
     <span id="version">v0.0.0</span>
   </footer>
+
+  <script>
+    if ("serviceWorker" in navigator) {
+      window.addEventListener("load", () => {
+        navigator.serviceWorker.register("../serviceworker.js").catch(console.error);
+      });
+    }
+  </script>
 </body>
 </html>

--- a/crop-production/crop-planting.html
+++ b/crop-production/crop-planting.html
@@ -6,34 +6,80 @@
   <meta name="theme-color" content="#365E5A" />
   <title>Planting — Farm Vista</title>
 
+  <!-- Prepaint theme -->
+  <script>
+  (function () {
+    var pref = localStorage.getItem('df_theme') || 'auto';
+    var dark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-theme', pref === 'auto' ? (dark ? 'dark' : 'light') : pref);
+    document.documentElement.style.colorScheme =
+      (pref === 'auto' ? (dark ? 'dark' : 'light') : pref) === 'dark' ? 'dark' : 'light';
+  })();
+  </script>
+
+  <!-- Global styles + app scripts -->
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
-  <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/version.js"></script>
+  <script defer src="../js/core.js"></script>
+
+  <!-- Page-only styles -->
+  <style>
+    .coming {
+      display:flex;
+      flex-direction:column;
+      align-items:center;
+      justify-content:center;
+      gap:10px;
+      padding:26px;
+      text-align:center;
+    }
+
+    .coming .emoji {
+      font-size:44px;
+      line-height:1;
+    }
+
+    .coming .title {
+      font-weight:800;
+      font-size:1.2rem;
+    }
+
+    .coming .hint {
+      opacity:.8;
+    }
+  </style>
 </head>
 <body>
+  <!-- Header -->
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
+      <img src="../assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
 
+  <!-- Breadcrumbs -->
   <nav class="breadcrumbs" aria-label="Breadcrumb">
     <ol>
-      <li><a href="index.html">Home</a></li>
+      <li><a href="../index.html">Home</a></li>
       <li class="sep">›</li>
-      <li><a href="crop.html">Crop Production</a></li>
+      <li><a href="index.html">Crop Production</a></li>
       <li class="sep">›</li>
       <li><span>Planting</span></li>
     </ol>
   </nav>
 
+  <!-- Main content -->
   <main class="content">
-    <h1>🌱 Planting</h1>
-    <p>🚧 Coming soon…</p>
+    <section class="card coming">
+      <div class="emoji">🌱</div>
+      <div class="title">Planting — Coming Soon</div>
+      <div class="hint">Lineups, hybrids, and prescriptions for each crew.</div>
+    </section>
   </main>
 
+  <!-- Footer -->
   <footer class="app-footer">
     <span>Farm Vista</span>
     <span class="dot">•</span>
@@ -41,5 +87,13 @@
     <span class="dot">•</span>
     <span id="version">v0.0.0</span>
   </footer>
+
+  <script>
+    if ("serviceWorker" in navigator) {
+      window.addEventListener("load", () => {
+        navigator.serviceWorker.register("../serviceworker.js").catch(console.error);
+      });
+    }
+  </script>
 </body>
 </html>

--- a/crop-production/crop-scouting.html
+++ b/crop-production/crop-scouting.html
@@ -6,34 +6,80 @@
   <meta name="theme-color" content="#365E5A" />
   <title>Crop Scouting — Farm Vista</title>
 
+  <!-- Prepaint theme -->
+  <script>
+  (function () {
+    var pref = localStorage.getItem('df_theme') || 'auto';
+    var dark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-theme', pref === 'auto' ? (dark ? 'dark' : 'light') : pref);
+    document.documentElement.style.colorScheme =
+      (pref === 'auto' ? (dark ? 'dark' : 'light') : pref) === 'dark' ? 'dark' : 'light';
+  })();
+  </script>
+
+  <!-- Global styles + app scripts -->
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
-  <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/version.js"></script>
+  <script defer src="../js/core.js"></script>
+
+  <!-- Page-only styles -->
+  <style>
+    .coming {
+      display:flex;
+      flex-direction:column;
+      align-items:center;
+      justify-content:center;
+      gap:10px;
+      padding:26px;
+      text-align:center;
+    }
+
+    .coming .emoji {
+      font-size:44px;
+      line-height:1;
+    }
+
+    .coming .title {
+      font-weight:800;
+      font-size:1.2rem;
+    }
+
+    .coming .hint {
+      opacity:.8;
+    }
+  </style>
 </head>
 <body>
+  <!-- Header -->
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
+      <img src="../assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
 
+  <!-- Breadcrumbs -->
   <nav class="breadcrumbs" aria-label="Breadcrumb">
     <ol>
-      <li><a href="index.html">Home</a></li>
+      <li><a href="../index.html">Home</a></li>
       <li class="sep">›</li>
-      <li><a href="crop.html">Crop Production</a></li>
+      <li><a href="index.html">Crop Production</a></li>
       <li class="sep">›</li>
       <li><span>Crop Scouting</span></li>
     </ol>
   </nav>
 
+  <!-- Main content -->
   <main class="content">
-    <h1>🔎 Crop Scouting</h1>
-    <p>🚧 Coming soon…</p>
+    <section class="card coming">
+      <div class="emoji">🔎</div>
+      <div class="title">Crop Scouting — Coming Soon</div>
+      <div class="hint">Capture field observations and imagery.</div>
+    </section>
   </main>
 
+  <!-- Footer -->
   <footer class="app-footer">
     <span>Farm Vista</span>
     <span class="dot">•</span>
@@ -41,5 +87,13 @@
     <span class="dot">•</span>
     <span id="version">v0.0.0</span>
   </footer>
+
+  <script>
+    if ("serviceWorker" in navigator) {
+      window.addEventListener("load", () => {
+        navigator.serviceWorker.register("../serviceworker.js").catch(console.error);
+      });
+    }
+  </script>
 </body>
 </html>

--- a/crop-production/crop-spraying.html
+++ b/crop-production/crop-spraying.html
@@ -6,34 +6,80 @@
   <meta name="theme-color" content="#365E5A" />
   <title>Spraying — Farm Vista</title>
 
+  <!-- Prepaint theme -->
+  <script>
+  (function () {
+    var pref = localStorage.getItem('df_theme') || 'auto';
+    var dark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-theme', pref === 'auto' ? (dark ? 'dark' : 'light') : pref);
+    document.documentElement.style.colorScheme =
+      (pref === 'auto' ? (dark ? 'dark' : 'light') : pref) === 'dark' ? 'dark' : 'light';
+  })();
+  </script>
+
+  <!-- Global styles + app scripts -->
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
-  <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/version.js"></script>
+  <script defer src="../js/core.js"></script>
+
+  <!-- Page-only styles -->
+  <style>
+    .coming {
+      display:flex;
+      flex-direction:column;
+      align-items:center;
+      justify-content:center;
+      gap:10px;
+      padding:26px;
+      text-align:center;
+    }
+
+    .coming .emoji {
+      font-size:44px;
+      line-height:1;
+    }
+
+    .coming .title {
+      font-weight:800;
+      font-size:1.2rem;
+    }
+
+    .coming .hint {
+      opacity:.8;
+    }
+  </style>
 </head>
 <body>
+  <!-- Header -->
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
+      <img src="../assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
     <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
 
+  <!-- Breadcrumbs -->
   <nav class="breadcrumbs" aria-label="Breadcrumb">
     <ol>
-      <li><a href="index.html">Home</a></li>
+      <li><a href="../index.html">Home</a></li>
       <li class="sep">›</li>
-      <li><a href="crop.html">Crop Production</a></li>
+      <li><a href="index.html">Crop Production</a></li>
       <li class="sep">›</li>
       <li><span>Spraying</span></li>
     </ol>
   </nav>
 
+  <!-- Main content -->
   <main class="content">
-    <h1>💦 Spraying</h1>
-    <p>🚧 Coming soon…</p>
+    <section class="card coming">
+      <div class="emoji">💦</div>
+      <div class="title">Spraying — Coming Soon</div>
+      <div class="hint">Mix sheets, rates, and application timing.</div>
+    </section>
   </main>
 
+  <!-- Footer -->
   <footer class="app-footer">
     <span>Farm Vista</span>
     <span class="dot">•</span>
@@ -41,5 +87,13 @@
     <span class="dot">•</span>
     <span id="version">v0.0.0</span>
   </footer>
+
+  <script>
+    if ("serviceWorker" in navigator) {
+      window.addEventListener("load", () => {
+        navigator.serviceWorker.register("../serviceworker.js").catch(console.error);
+      });
+    }
+  </script>
 </body>
 </html>

--- a/crop-production/crop-trials.html
+++ b/crop-production/crop-trials.html
@@ -6,37 +6,77 @@
   <meta name="theme-color" content="#365E5A" />
   <title>Trials — Farm Vista</title>
 
+  <!-- Prepaint theme -->
+  <script>
+  (function () {
+    var pref = localStorage.getItem('df_theme') || 'auto';
+    var dark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-theme', pref === 'auto' ? (dark ? 'dark' : 'light') : pref);
+    document.documentElement.style.colorScheme =
+      (pref === 'auto' ? (dark ? 'dark' : 'light') : pref) === 'dark' ? 'dark' : 'light';
+  })();
+  </script>
+
+  <!-- Global styles + app scripts -->
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
-  <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/version.js"></script>
+  <script defer src="../js/core.js"></script>
+
+  <!-- Page-only styles -->
+  <style>
+    .coming {
+      display:flex;
+      flex-direction:column;
+      align-items:center;
+      justify-content:center;
+      gap:10px;
+      padding:26px;
+      text-align:center;
+    }
+
+    .coming .emoji {
+      font-size:44px;
+      line-height:1;
+    }
+
+    .coming .title {
+      font-weight:800;
+      font-size:1.2rem;
+    }
+
+    .coming .hint {
+      opacity:.8;
+    }
+  </style>
 </head>
 <body>
   <!-- Header -->
   <header class="app-header">
     <div class="app-header__left">
-      <img src="assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
+      <img src="../assets/icons/Farm_Vista_Logo.png" alt="Farm Vista Logo" class="app-logo" />
       <div class="app-header__title">Farm Vista</div>
     </div>
-    <div class="app-header__right">
-      <span id="clock" class="clock">--:--</span>
-    </div>
+    <div class="app-header__right"><span id="clock" class="clock">--:--</span></div>
   </header>
 
   <!-- Breadcrumbs -->
   <nav class="breadcrumbs" aria-label="Breadcrumb">
     <ol>
-      <li><a href="index.html">Home</a></li>
+      <li><a href="../index.html">Home</a></li>
       <li class="sep">›</li>
-      <li><a href="crop.html">Crop Production</a></li>
+      <li><a href="index.html">Crop Production</a></li>
       <li class="sep">›</li>
       <li><span>Trials</span></li>
     </ol>
   </nav>
 
-  <!-- Main -->
+  <!-- Main content -->
   <main class="content">
-    <h1>🧬 Trials</h1>
-    <p>🚧 Coming soon…</p>
+    <section class="card coming">
+      <div class="emoji">🧬</div>
+      <div class="title">Trials — Coming Soon</div>
+      <div class="hint">Log trial layouts and results for future seasons.</div>
+    </section>
   </main>
 
   <!-- Footer -->
@@ -47,5 +87,13 @@
     <span class="dot">•</span>
     <span id="version">v0.0.0</span>
   </footer>
+
+  <script>
+    if ("serviceWorker" in navigator) {
+      window.addEventListener("load", () => {
+        navigator.serviceWorker.register("../serviceworker.js").catch(console.error);
+      });
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refresh each crop production sub-menu page to use the new Farm Vista theme prepaint, header, breadcrumbs, and card layout
- update asset paths and localized messaging for planting, spraying, aerial, harvest, fertilizer, scouting, maintenance, and trial modules
- ensure each page registers the shared service worker for consistency with the rest of the app

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e0fa14d7f08321ad2d955f34cf8a7d