### PR TITLE
Adjust global header safe area and unify legacy pages

### DIFF
--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -1,11 +1,25 @@
 /* Farm Vista — Global Header (fixed, Farm Vista gradient, mobile-first) */
 
 :root {
-  --fv-header-height: 76px;
+  --fv-header-base-height: 76px;
+  --fv-safe-top: 0px;
+  --fv-header-height: calc(var(--fv-header-base-height) + var(--fv-safe-top));
 }
 
-html, body { height: 100%; }
-body { padding-top: var(--fv-header-height); }
+@supports (padding-top: env(safe-area-inset-top)) {
+  :root {
+    --fv-safe-top: env(safe-area-inset-top);
+  }
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  padding-top: var(--fv-header-height);
+}
 
 .app-header {
   position: fixed;
@@ -15,7 +29,7 @@ body { padding-top: var(--fv-header-height); }
   align-items: stretch;
   justify-content: flex-start;
   gap: 14px;
-  padding: 10px 18px 12px;
+  padding: calc(var(--fv-safe-top) + 10px) 18px 12px;
   background: linear-gradient(120deg, rgba(54, 94, 90, 0.95), rgba(216, 193, 121, 0.88));
   color: #fefcf4;
   z-index: 1000;
@@ -30,12 +44,12 @@ body { padding-top: var(--fv-header-height); }
   border-radius: 14px;
   padding: 6px 10px;
   margin: 0;
-  margin-top: auto;
   cursor: pointer;
   font-size: 22px;
   line-height: 1;
   color: #fefcf4;
   transition: background 0.18s ease, border-color 0.18s ease;
+  align-self: center;
 }
 
 .app-header .burger:focus-visible {
@@ -108,10 +122,13 @@ body { padding-top: var(--fv-header-height); }
 }
 
 @media (max-width: 640px) {
-  :root { --fv-header-height: 72px; }
+  :root {
+    --fv-header-base-height: 72px;
+  }
   .app-header {
     gap: 10px;
     padding: 8px 14px 10px;
+    padding-top: calc(var(--fv-safe-top) + 8px);
   }
 }
 

--- a/calculators/calc-area.html
+++ b/calculators/calc-area.html
@@ -16,7 +16,7 @@
 
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
   <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/core.js"></script>
 
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/calculators/calc-chemical-mix.html
+++ b/calculators/calc-chemical-mix.html
@@ -16,7 +16,7 @@
 
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
   <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/core.js"></script>
 
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/calculators/calc-combine-yield.html
+++ b/calculators/calc-combine-yield.html
@@ -16,7 +16,7 @@
 
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
   <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/core.js"></script>
 
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/calculators/calc-grain-bin.html
+++ b/calculators/calc-grain-bin.html
@@ -16,7 +16,7 @@
 
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
   <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/core.js"></script>
 
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/calculators/calc-grain-shrink.html
+++ b/calculators/calc-grain-shrink.html
@@ -16,7 +16,7 @@
 
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
   <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/core.js"></script>
 
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/calculators/calc-trial-yields.html
+++ b/calculators/calc-trial-yields.html
@@ -18,7 +18,7 @@
 
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
   <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/core.js"></script>
 
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/equipment/equipment-combines.html
+++ b/equipment/equipment-combines.html
@@ -16,7 +16,7 @@
 
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
   <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/core.js"></script>
 
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/equipment/equipment-construction.html
+++ b/equipment/equipment-construction.html
@@ -16,7 +16,7 @@
 
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
   <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/core.js"></script>
 
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/equipment/equipment-implements.html
+++ b/equipment/equipment-implements.html
@@ -16,7 +16,7 @@
 
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
   <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/core.js"></script>
 
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/equipment/equipment-sprayers.html
+++ b/equipment/equipment-sprayers.html
@@ -16,7 +16,7 @@
 
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
   <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/core.js"></script>
 
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/equipment/equipment-starfire.html
+++ b/equipment/equipment-starfire.html
@@ -16,7 +16,7 @@
 
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
   <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/core.js"></script>
 
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/equipment/equipment-tractors.html
+++ b/equipment/equipment-tractors.html
@@ -8,7 +8,7 @@
 
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
   <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/core.js"></script>
 
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/equipment/equipment-trailers.html
+++ b/equipment/equipment-trailers.html
@@ -16,7 +16,7 @@
 
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
   <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/core.js"></script>
 
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/equipment/equipment-trucks.html
+++ b/equipment/equipment-trucks.html
@@ -16,7 +16,7 @@
 
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
   <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/core.js"></script>
 
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/feedback/bugs.html
+++ b/feedback/bugs.html
@@ -19,7 +19,7 @@
 
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
   <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/core.js"></script>
 
   <!-- Global Menus (DF_MENUS) -->
   <script defer src="assets/data/menus.js"></script>

--- a/grain-tracking/grain-bags.html
+++ b/grain-tracking/grain-bags.html
@@ -16,7 +16,7 @@
 
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
   <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/core.js"></script>
 
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/grain-tracking/grain-bins.html
+++ b/grain-tracking/grain-bins.html
@@ -16,7 +16,7 @@
 
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
   <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/core.js"></script>
 
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/grain-tracking/grain-contracts.html
+++ b/grain-tracking/grain-contracts.html
@@ -16,7 +16,7 @@
 
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
   <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/core.js"></script>
 
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/grain-tracking/grain-ticket-ocr.html
+++ b/grain-tracking/grain-ticket-ocr.html
@@ -16,7 +16,7 @@
 
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
   <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/core.js"></script>
 
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/js/core.js
+++ b/js/core.js
@@ -1,0 +1,61 @@
+(async function () {
+  const current = document.currentScript || (function () {
+    const scripts = document.getElementsByTagName("script");
+    for (let i = scripts.length - 1; i >= 0; i -= 1) {
+      const src = scripts[i].src || "";
+      if (src.includes("/js/core")) return scripts[i];
+    }
+    return null;
+  })();
+
+  const root = current ? new URL("../", new URL(current.src, location.href)).href : location.origin + "/";
+
+  const toUrl = (relative) => new URL(relative.replace(/^\//, ""), root).href;
+
+  const existingScript = (href) => Array.from(document.scripts || []).some((scr) => scr.src === href);
+  const existingStyle = (href) => Array.from(document.querySelectorAll('link[rel="stylesheet"]')).some((lnk) => lnk.href === href);
+
+  const ensureStylesheet = (relativeHref) => {
+    const href = toUrl(relativeHref);
+    if (existingStyle(href)) return;
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = href;
+    document.head.appendChild(link);
+  };
+
+  const ensureScript = (relativeSrc, { type } = {}) => {
+    const src = toUrl(relativeSrc);
+    if (existingScript(src)) return Promise.resolve();
+    return new Promise((resolve, reject) => {
+      const script = document.createElement("script");
+      if (type) script.type = type;
+      if (!type || type === "text/javascript") script.async = false;
+      script.src = src;
+      script.onload = () => resolve();
+      script.onerror = () => reject(new Error(`Failed to load ${src}`));
+      document.head.appendChild(script);
+    });
+  };
+
+  // Hide any legacy headers so page-specific scripts can still target them without duplicating UI
+  Array.from(document.querySelectorAll("body > header")).forEach((header) => {
+    if (header.dataset && header.dataset.fvGlobal === "1") return;
+    header.setAttribute("hidden", "hidden");
+    header.style.display = "none";
+  });
+
+  // Ensure the modern header + drawer styles are present
+  ensureStylesheet("assets/css/header.css");
+  ensureStylesheet("assets/css/drawer.css");
+
+  try {
+    await ensureScript("assets/data/drawer-menus.js");
+    await ensureScript("js/version.js");
+    await ensureScript("js/header.js");
+    await ensureScript("js/footer.js");
+    await ensureScript("js/drawer.js", { type: "module" });
+  } catch (err) {
+    console.warn("Farm Vista core shell failed to load:", err);
+  }
+})();

--- a/js/header.js
+++ b/js/header.js
@@ -1,7 +1,11 @@
 // Farm Vista — Global Header (green theme)
 (function () {
+  if (document.querySelector('header[data-fv-global="1"]')) return;
+
   const header = document.createElement("header");
   header.className = "app-header";
+  header.dataset.fvGlobal = "1";
+  header.setAttribute("role", "banner");
   header.innerHTML = `
     <button id="drawerToggle" class="burger" aria-label="Open menu">☰</button>
     <div class="header-breadcrumbs" role="presentation"></div>

--- a/reports/reports-ai-history.html
+++ b/reports/reports-ai-history.html
@@ -16,7 +16,7 @@
 
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
   <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/core.js"></script>
 
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/reports/reports-ai.html
+++ b/reports/reports-ai.html
@@ -16,7 +16,7 @@
 
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
   <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/core.js"></script>
 
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/reports/reports-predefined.html
+++ b/reports/reports-predefined.html
@@ -16,7 +16,7 @@
 
   <link rel="stylesheet" href="../assets/css/theme.css?v=24" />
   <script defer src="version.js"></script>
-  <script defer src="core.js"></script>
+  <script defer src="../js/core.js"></script>
 
   <link rel="manifest" href="manifest.webmanifest" />
   <meta name="apple-mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
## Summary
- add safe-area aware sizing to the global header so the drawer toggle sits below iOS status areas
- load the shared header/drawer/footer shell from core.js and hide legacy headers when the shell is injected
- point legacy calculators, grain tracking, equipment, reports, and feedback pages at the shared core script so they receive the global shell

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e112ce0b208321bf8c46a85806807d