### PR TITLE
Adjust header layout for centered date

### DIFF
--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -1,7 +1,7 @@
 /* Farm Vista — Global Header (fixed, Farm Vista gradient, mobile-first) */
 
 :root {
-  --fv-header-base-height: 76px;
+  --fv-header-base-height: 96px;
   --fv-safe-top: 0px;
   --fv-header-height: calc(var(--fv-header-base-height) + var(--fv-safe-top));
 }
@@ -26,10 +26,10 @@ body {
   inset: 0 0 auto 0;
   height: var(--fv-header-height);
   display: flex;
-  align-items: stretch;
+  align-items: center;
   justify-content: flex-start;
   gap: 14px;
-  padding: calc(var(--fv-safe-top) + 10px) 18px 12px;
+  padding: calc(var(--fv-safe-top) + 12px) 18px 18px;
   background: linear-gradient(120deg, rgba(54, 94, 90, 0.95), rgba(216, 193, 121, 0.88));
   color: #fefcf4;
   z-index: 1000;
@@ -62,12 +62,22 @@ body {
   border-color: rgba(251, 249, 240, 0.55);
 }
 
-.app-header .header-breadcrumbs {
+
+.app-header .header-main {
   flex: 1;
   min-width: 0;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  align-self: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.app-header .header-breadcrumbs {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .app-header img.app-logo {
@@ -105,14 +115,18 @@ body {
   opacity: 0.55;
 }
 
+.app-header .header-date {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
 .app-header .clock {
   color: rgba(254, 252, 244, 0.85);
   font-size: 14px;
   font-variant-numeric: tabular-nums;
   letter-spacing: 0.02em;
-  text-align: right;
-  margin-left: auto;
-  margin-bottom: auto;
+  text-align: center;
 }
 
 .app-header a {
@@ -123,12 +137,15 @@ body {
 
 @media (max-width: 640px) {
   :root {
-    --fv-header-base-height: 72px;
+    --fv-header-base-height: 92px;
   }
   .app-header {
     gap: 10px;
-    padding: 8px 14px 10px;
+    padding: 10px 14px 16px;
     padding-top: calc(var(--fv-safe-top) + 8px);
+  }
+  .app-header .header-main {
+    gap: 4px;
   }
 }
 

--- a/js/header.js
+++ b/js/header.js
@@ -8,8 +8,12 @@
   header.setAttribute("role", "banner");
   header.innerHTML = `
     <button id="drawerToggle" class="burger" aria-label="Open menu">☰</button>
-    <div class="header-breadcrumbs" role="presentation"></div>
-    <span id="dateDisplay" class="clock">--/--/----</span>
+    <div class="header-main" role="presentation">
+      <div class="header-breadcrumbs" role="presentation"></div>
+      <div class="header-date" role="presentation">
+        <span id="dateDisplay" class="clock">--/--/----</span>
+      </div>
+    </div>
   `;
   document.body.prepend(header);
 


### PR DESCRIPTION
## Summary
- wrap header breadcrumbs and date inside a new container to allow stacked layout
- expand header spacing and styling so the gradient remains behind breadcrumbs and the date centers beneath them

## Testing
- Not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e12a97dc5c8321ab1fef7f7756ca4f