### PR TITLE
Reload settings after successful update check

### DIFF
--- a/settings/index.html
+++ b/settings/index.html
@@ -146,6 +146,18 @@
         );
       };
 
+      const reloadWithNotice = (delayMs = 1500) => {
+        window.setTimeout(() => {
+          try {
+            const base = location.href.split("#")[0];
+            location.href = `${base}#check-updates`;
+            location.reload();
+          } catch (_) {
+            location.reload();
+          }
+        }, delayMs);
+      };
+
       btn.addEventListener("click", async (event) => {
         event.preventDefault();
         event.stopPropagation();
@@ -159,7 +171,8 @@
           await refreshServiceWorkers(hasNewer);
           const displayVersion = latestVersion || currentVersion || "unknown";
           if (hasNewer) {
-            msg.textContent = `New version ${latestVersion} available. Caches cleared.`;
+            msg.textContent = `New version ${latestVersion} available. Reloading…`;
+            reloadWithNotice();
           } else {
             msg.textContent = `Already on latest version (${displayVersion}). Caches cleared.`;
           }


### PR DESCRIPTION
## Summary
- ensure the settings "Check for Updates" button reloads the app after finding a new version
- preserve the check-updates anchor when reloading so the user lands back on the update section

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e14d74328483218774f5b4f44c3ae8