### PR TITLE
Improve update check access from navigation

### DIFF
--- a/js/drawer.js
+++ b/js/drawer.js
@@ -99,6 +99,13 @@
     a.href = href || "#";
     a.innerHTML = `<span class="icon">${icon || ""}</span>${label}`;
     a.addEventListener("click", closeDrawer);
+    if ((href || "").includes("settings/index.html#check-updates")) {
+      a.addEventListener("click", () => {
+        try {
+          sessionStorage.setItem("fvAutoUpdateCheck", "1");
+        } catch (_) {}
+      });
+    }
     return a;
   };
 

--- a/js/ui-nav.js
+++ b/js/ui-nav.js
@@ -6,6 +6,19 @@ import { loadAccess } from "./access.js";
 
 const $ = (s) => document.querySelector(s);
 
+const UPDATE_CHECK_HREF = "settings/index.html#check-updates";
+
+function bindAutoUpdateFlag(anchor) {
+  if (!anchor) return;
+  const href = anchor.getAttribute("href") || "";
+  if (!href.includes(UPDATE_CHECK_HREF)) return;
+  anchor.addEventListener("click", () => {
+    try {
+      sessionStorage.setItem("fvAutoUpdateCheck", "1");
+    } catch (_) {}
+  });
+}
+
 function renderHome(tiles){
   const container = document.querySelector("[data-df-tiles]");
   if(!container) return;
@@ -32,6 +45,7 @@ function renderHome(tiles){
     a.style.textDecoration="none";
     a.style.color="#143231";
     a.innerHTML = `${t.iconEmoji || "•"} <span style="margin-top:8px;font-weight:600">${t.label}</span>`;
+    bindAutoUpdateFlag(a);
     grid.appendChild(a);
   });
 
@@ -59,6 +73,7 @@ function renderSubnav(sectionHref, topTile, children){
     a.style.textDecoration="none";
     a.style.color="#143231";
     a.textContent = ch.label;
+    bindAutoUpdateFlag(a);
     list.appendChild(a);
   });
 

--- a/settings/index.html
+++ b/settings/index.html
@@ -84,14 +84,16 @@
     .update-card {
       display: flex;
       flex-direction: column;
-      gap: 12px;
+      gap: 16px;
     }
 
     .update-actions {
       display: flex;
+      flex-direction: column;
       align-items: center;
+      justify-content: center;
       gap: 12px;
-      flex-wrap: wrap;
+      text-align: center;
     }
 
     .update-status {
@@ -159,7 +161,7 @@
       <p>Check for the latest build, refresh caches, and reload the app.</p>
       <div class="update-actions">
         <button id="btnCheckUpdates" class="btn-primary">Check for Updates</button>
-        <span id="updMsg" class="update-status" aria-live="polite">Not checked yet.</span>
+        <span id="updMsg" class="update-status" aria-live="polite" hidden></span>
       </div>
     </section>
   </main>
@@ -374,6 +376,7 @@
 
       btn.disabled = true;
       btn.textContent = 'Checking…';
+      statusEl.hidden = false;
       statusEl.textContent = 'Checking for updates…';
 
       try {
@@ -400,6 +403,24 @@
         btn.textContent = originalText;
       }
     });
+
+    const autoFlag = 'fvAutoUpdateCheck';
+    const shouldAutoCheck = (() => {
+      try {
+        if (sessionStorage.getItem(autoFlag) === '1') {
+          sessionStorage.removeItem(autoFlag);
+          return true;
+        }
+      } catch (_) {}
+      return (location.hash || '').includes('auto-check');
+    })();
+
+    if (shouldAutoCheck && btn) {
+      window.requestAnimationFrame(() => {
+        btn.focus();
+        btn.click();
+      });
+    }
 
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- center the App Updates button and hide the idle status text on the settings page
- automatically run the update check when landing via navigation shortcuts
- flag sidebar, home, and sub-navigation links to request an automatic update check

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e159f9d3f08321ade9ae538fff7c8d